### PR TITLE
Fix: Prevent display of anachronistic test results

### DIFF
--- a/site_1.py
+++ b/site_1.py
@@ -1265,9 +1265,29 @@ def create_test():
             if test_type == 'add_letter':
                 prompt_for_test_word_model = original_translation
                 if test_mode == 'random_letters':
-                    if len(original_word_text) > 0:
-                        num_letters_to_remove = random.randint(1, min(2, len(original_word_text)))
-                        positions_zero_indexed = sorted(random.sample(range(len(original_word_text)), num_letters_to_remove))
+                    letter_indices = [i for i, char in enumerate(original_word_text) if char != ' ']
+                    num_actual_letters = len(letter_indices)
+
+                    if num_actual_letters > 0:
+                        # Determine base number of letters to remove based on actual letter count
+                        if num_actual_letters <= 3:
+                            val = 1
+                        elif num_actual_letters <= 6:
+                            val = random.randint(1, 2)
+                        elif num_actual_letters <= 9:
+                            val = random.randint(2, 3)
+                        else: # 10+ actual letters
+                            val = random.randint(3, 4)
+
+                        # Adjust num_letters_to_remove
+                        if num_actual_letters == 1: # For a single letter word, always remove that one letter
+                            num_letters_to_remove = 1
+                        else:
+                            # For words with more than one letter, remove at most half, but at least 1
+                            num_letters_to_remove = min(val, num_actual_letters // 2)
+                            num_letters_to_remove = max(1, num_letters_to_remove)
+
+                        positions_zero_indexed = sorted(random.sample(letter_indices, num_letters_to_remove))
                         
                         actual_missing_letters_list = [original_word_text[pos] for pos in positions_zero_indexed]
                         correct_answer_for_db = "".join(actual_missing_letters_list)
@@ -1276,9 +1296,10 @@ def create_test():
                         for pos in positions_zero_indexed:
                             word_with_gaps_list[pos] = '_'
                         current_word_for_test_word_model = "".join(word_with_gaps_list)
-                        missing_letters_positions_db = ','.join(str(pos + 1) for pos in positions_zero_indexed)
-                    else:
-                        current_word_for_test_word_model = ""
+                        missing_letters_positions_db = ','.join(str(pos + 1) for pos in positions_zero_indexed) # Store 1-indexed
+
+                    else: # No actual letters in original_word_text (it's empty or all spaces)
+                        current_word_for_test_word_model = original_word_text
                         correct_answer_for_db = ""
                         missing_letters_positions_db = ""
                 elif test_mode == 'manual_letters':
@@ -1547,7 +1568,10 @@ def test_details(test_id):
         # Teacher's view: Gather student progress and render details page
         students_in_class = User.query.filter_by(class_number=test.classs, teacher='no').all()
         total_students_in_class = len(students_in_class)
-        all_results_for_test = TestResult.query.filter_by(test_id=test.id).all()
+        all_results_for_test = TestResult.query.filter(
+            TestResult.test_id == test.id,
+            TestResult.started_at >= test.created_at
+        ).all()
 
         completed_students_details = []
         in_progress_students_details = []
@@ -2425,7 +2449,10 @@ def test_details_data(test_id):
 
     students_in_class = User.query.filter_by(class_number=test.classs, teacher='no').all()
     total_students_in_class = len(students_in_class)
-    all_results_for_test = TestResult.query.filter_by(test_id=test.id).all()
+    all_results_for_test = TestResult.query.filter(
+        TestResult.test_id == test.id,
+        TestResult.started_at >= test.created_at
+    ).all()
 
     completed_students_details_json = []
     in_progress_students_details_json = []

--- a/templates/test_add_letter.html
+++ b/templates/test_add_letter.html
@@ -4,59 +4,179 @@
 
 {% block head_extra %}
 <style>
-    .letter-input {
-        width: 25px; /* Adjust size as needed */
-        height: 30px; /* Adjust size as needed */
-        text-align: center;
-        font-size: 1.2em;
-        margin: 0 2px;
-        border: 1px solid #ccc;
-        border-radius: 4px;
-    }
-    .word-display {
-        display: flex;
-        align-items: center;
-        font-size: 1.5em; /* Make overall word display larger */
-        margin-bottom: 15px;
-    }
-    .word-char {
-        margin: 0 1px;
-        line-height: 30px; /* Align with input box height */
-    }
-    .prompt-translation {
-        font-style: italic;
-        color: #555;
-        margin-bottom: 20px;
-    }
-    /* Basic Timer Styling (Placeholder) */
-    #timer {
-        font-size: 1.5em;
-        font-weight: bold;
-        color: #333;
-        margin-bottom: 20px;
-        text-align: center;
-    }
-    /* Basic Navigation Panel Styling (Placeholder) */
-    .nav-panel {
-        display: flex;
-        justify-content: center;
-        margin-bottom: 20px;
-        flex-wrap: wrap;
-    }
-    .nav-item {
-        width: 20px;
-        height: 20px;
-        border: 1px solid #ccc;
-        margin: 2px;
-        background-color: #eee;
-        cursor: pointer;
-    }
-    .nav-item.completed {
-        background-color: #2ed573; /* Green */
-    }
-    .nav-item.current {
-        border: 2px solid #6c63ff; /* Primary color */
-    }
+/* General */
+.container {
+    max-width: 800px;
+    margin: auto;
+    padding-top: 20px; /* Added padding */
+}
+h1 {
+    text-align: center;
+    color: #333;
+    margin-bottom: 30px; /* Increased margin */
+    font-size: 2em; /* Larger heading */
+}
+
+/* Question Header (New Element) */
+.question-header {
+    font-size: 1.2em;
+    font-weight: bold;
+    margin-bottom: 15px; /* Increased margin */
+    color: #444;
+    text-align: center;
+}
+
+/* Word Container - for overall structure of each question */
+.word-container {
+    background-color: #ffffff;
+    padding: 25px; /* Increased padding */
+    border-radius: 8px;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.05); /* Softer shadow */
+    margin-bottom: 25px;
+    border: 1px solid #e0e0e0; /* Added border */
+    transition: box-shadow 0.3s ease-in-out; /* Transition for hover */
+}
+.word-container:hover {
+    box-shadow: 0 6px 12px rgba(0,0,0,0.08); /* Slightly larger shadow on hover */
+}
+
+/* Prompt */
+.prompt-translation {
+    font-style: italic;
+    color: #555;
+    margin-bottom: 15px;
+    text-align: center;
+    font-size: 1.1em;
+}
+
+/* Word Display */
+.word-display {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.8em;
+    margin-bottom: 20px;
+}
+.letter-input {
+    width: 35px; /* Increased */
+    height: 40px; /* Increased */
+    text-align: center;
+    font-size: 1.4em;
+    margin: 0 4px; /* Increased */
+    border: 1px solid #ccc;
+    border-radius: 5px;
+    box-shadow: inset 0 1px 2px rgba(0,0,0,0.1);
+    transition: border-color .15s ease-in-out, box-shadow .15s ease-in-out; /* Added transition */
+    background-color: #fdfdfd; /* Subtle background for inputs */
+}
+.letter-input:focus {
+    border-color: #6c63ff;
+    box-shadow: 0 0 0 0.2rem rgba(108, 99, 255, 0.25), inset 0 1px 2px rgba(0,0,0,0.1); /* Keep inner shadow on focus */
+}
+.word-char {
+    margin: 0 3px; /* Increased */
+    line-height: 40px; /* Match input height */
+    color: #333;
+    min-width: 20px; /* Give some space for narrow chars */
+    display: inline-block; /* For alignment */
+    text-align: center;
+}
+
+/* Navigation Panel */
+.nav-panel {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    margin-bottom: 30px; /* Increased margin */
+    padding: 10px;
+    background-color: #f8f9fa; /* Light background for panel from question-item */
+    border-radius: 6px;
+}
+.nav-item {
+    width: 32px; /* Larger */
+    height: 32px; /* Larger */
+    border: 1px solid #ced4da; /* Consistent border color */
+    margin: 4px; /* Increased margin */
+    background-color: #e9ecef; /* Slightly different background */
+    color: #495057; /* Darker text for contrast */
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.9em;
+    border-radius: 4px;
+    transition: background-color 0.2s, border-color 0.2s, color 0.2s;
+    font-weight: 500; /* Slightly bolder numbers */
+}
+.nav-item:hover {
+    background-color: #dee2e6;
+    border-color: #adb5bd;
+}
+.nav-item.completed {
+    background-color: #28a745; /* Bootstrap success green */
+    border-color: #1e7e34;
+    color: #fff;
+}
+.nav-item.current {
+    border-color: #6c63ff;
+    background-color: #e6e3ff;
+    color: #6c63ff; /* Text color matches border */
+    font-weight: bold;
+    box-shadow: 0 0 5px rgba(108, 99, 255, 0.5); /* Subtle glow for current */
+    border-width: 2px; /* Thicker border for current */
+}
+
+/* Timer */
+#timer {
+    font-size: 1.3em; /* Adjusted size */
+    font-weight: bold;
+    color: #495057; /* Darker color for better contrast on light bg */
+    margin-bottom: 30px; /* Increased margin */
+    text-align: center;
+    padding: 12px; /* Increased padding */
+    background-color: #e9ecef;
+    border: 1px solid #ced4da; /* Added border */
+    border-radius: 6px;
+}
+
+/* Buttons */
+.button-container {
+    text-align: center;
+    margin-top: 25px; /* Increased margin */
+    margin-bottom: 25px; /* Added margin for space below buttons */
+}
+.button-container .btn {
+    margin: 0 8px; /* Increased space between buttons */
+    padding: 10px 20px;
+    font-size: 1em;
+    min-width: 100px; /* Ensure buttons have a decent minimum width */
+}
+/* Assuming Bootstrap handles basic button styling, these are specific hover overrides if needed */
+.button-container .btn-primary:hover {
+    background-color: #564ee0; /* Slightly darker primary */
+    border-color: #4d44c4;
+}
+.button-container .btn-secondary:hover {
+    background-color: #5a6268;
+    border-color: #545b62;
+}
+.button-container .btn-success:hover {
+    background-color: #218838;
+    border-color: #1e7e34;
+}
+.button-container .btn:active {
+    transform: translateY(1px); /* Simple pressed effect */
+}
+
+/* Add a general focus outline style for accessibility if not already present */
+*:focus-visible {
+    outline: 2px solid #6c63ff !important; /* Or your primary color */
+    outline-offset: 2px !important;
+}
+/* Remove default outline if using focus-visible, for elements that have custom focus styles */
+.letter-input:focus, .button-container .btn:focus {
+    outline: none; /* Remove default if custom box-shadow or other indicators are sufficient */
+}
 </style>
 {% endblock %}
 
@@ -79,12 +199,13 @@
             {# Placeholder for Navigation Panel #}
             <div class="nav-panel">
                 {% for word_item in words %}
-                <div class="nav-item" data-word-id="{{ word_item.id }}"></div>
+                <div class="nav-item" data-word-id="{{ word_item.id }}">{{ loop.index }}</div>
                 {% endfor %}
             </div>
 
             {% for word_item in words %}
             <div class="word-container mb-4" data-word-id="{{ word_item.id }}">
+                <p class="question-header">Вопрос {{ loop.index }} из {{ words|length }}</p>
                 <p class="prompt-translation">Перевод: {{ word_item.perevod }}</p>
                 <div class="word-display">
                     {% for char in word_item.word %}
@@ -100,7 +221,7 @@
             <p>Нет слов для этого теста.</p>
             {% endfor %}
 
-            <div class="mt-4">
+            <div class="button-container">
                 <button type="button" id="prevWordBtn" class="btn btn-secondary" style="display: none;">Назад</button>
                 <button type="button" id="nextWordBtn" class="btn btn-primary">Далее</button>
                 <button type="submit" id="submitTestBtn" class="btn btn-success" style="display: none;">Завершить тест</button>


### PR DESCRIPTION
In the teacher's view of test details (`test_details` page and its corresponding API endpoint `test_details_data`), this commit modifies the queries fetching student test results.

An additional condition, `TestResult.started_at >= Test.created_at`, has been added. This ensures that only results started on or after the test's creation time are displayed.

This is a defensive measure to prevent scenarios (e.g., potential data inconsistencies or highly unlikely test ID reuse with orphaned data) where a newly created test might erroneously appear to have student results that predate its own creation.