### PR TITLE
I've implemented anti-cheating measures for tests.

### DIFF
--- a/static/js/anti_cheat.js
+++ b/static/js/anti_cheat.js
@@ -1,0 +1,34 @@
+// Disable right-click context menu
+document.addEventListener('contextmenu', event => event.preventDefault());
+
+// Disable text selection
+document.addEventListener('selectstart', event => event.preventDefault());
+
+// Disable copy-paste and cut
+document.addEventListener('copy', event => event.preventDefault());
+document.addEventListener('paste', event => event.preventDefault());
+document.addEventListener('cut', event => event.preventDefault());
+
+// Disable keyboard shortcuts for developer tools
+document.addEventListener('keydown', function(event) {
+    // F12
+    if (event.key === 'F12') {
+        event.preventDefault();
+    }
+    // Ctrl+Shift+I
+    if (event.ctrlKey && event.shiftKey && event.key === 'I') {
+        event.preventDefault();
+    }
+    // Ctrl+Shift+J
+    if (event.ctrlKey && event.shiftKey && event.key === 'J') {
+        event.preventDefault();
+    }
+    // Ctrl+Shift+C
+    if (event.ctrlKey && event.shiftKey && event.key === 'C') {
+        event.preventDefault();
+    }
+    // Ctrl+U
+    if (event.ctrlKey && event.key === 'U') {
+        event.preventDefault();
+    }
+});

--- a/templates/take_test.html
+++ b/templates/take_test.html
@@ -241,6 +241,7 @@
         </div>
     </div>
 
+    <script src="{{ url_for('static', filename='js/anti_cheat.js') }}" defer></script>
     <script>
         const testData = {
             id: {{ test.id }},

--- a/templates/test_add_letter.html
+++ b/templates/test_add_letter.html
@@ -236,5 +236,6 @@ h1 {
 
 {% block scripts %}
 {{ super() }}
+<script src="{{ url_for('static', filename='js/anti_cheat.js') }}" defer></script>
 <script src="/static/js/test_add_letter.js" defer></script>
 {% endblock %}

--- a/templates/test_dictation.html
+++ b/templates/test_dictation.html
@@ -247,6 +247,7 @@
     </form>
 </div>
 
+<script src="{{ url_for('static', filename='js/anti_cheat.js') }}" defer></script>
 <script src="/static/js/test_dictation.js" defer></script>
 
 </body>

--- a/templates/test_fill_word.html
+++ b/templates/test_fill_word.html
@@ -102,5 +102,6 @@
 
 {% block scripts %}
 {{ super() }}
+<script src="{{ url_for('static', filename='js/anti_cheat.js') }}" defer></script>
 <script src="/static/js/test_fill_word.js" defer></script>
 {% endblock %}

--- a/templates/test_multiple_choice.html
+++ b/templates/test_multiple_choice.html
@@ -232,6 +232,7 @@
         </form>
     </div>
 
+    <script src="{{ url_for('static', filename='js/anti_cheat.js') }}" defer></script>
     <script id="mcSingleWordsData" type="application/json">
         {{ words | tojson | safe }}
     </script>

--- a/templates/test_multiple_choice_multiple.html
+++ b/templates/test_multiple_choice_multiple.html
@@ -108,5 +108,6 @@
 
 {% block scripts %}
 {{ super() }}
+<script src="{{ url_for('static', filename='js/anti_cheat.js') }}" defer></script>
 <script src="/static/js/test_multiple_choice_multiple.js" defer></script>
 {% endblock %}

--- a/templates/test_start.html
+++ b/templates/test_start.html
@@ -246,5 +246,6 @@
             </form>
         </div>
     </div>
+    <script src="{{ url_for('static', filename='js/anti_cheat.js') }}" defer></script>
 </body>
 </html> 

--- a/templates/test_true_false.html
+++ b/templates/test_true_false.html
@@ -98,5 +98,6 @@
 
 {% block scripts %}
 {{ super() }}
+<script src="{{ url_for('static', filename='js/anti_cheat.js') }}" defer></script>
 <script src="/static/js/test_true_false.js" defer></script>
 {% endblock %}


### PR DESCRIPTION
This commit introduces JavaScript-based restrictions to prevent cheating during tests.

The following measures have been implemented:
- Disabled right-click context menu.
- Disabled text selection.
- Disabled copy, paste, and cut operations (Ctrl+C, Ctrl+V, Ctrl+X).
- Disabled keyboard shortcuts for opening browser developer tools (F12, Ctrl+Shift+I, Ctrl+Shift+J, Ctrl+Shift+C, Ctrl+U).

A new file, `static/js/anti_cheat.js`, contains the core logic for these restrictions. This script is now included in all relevant test-related HTML templates:
- `templates/test_add_letter.html`
- `templates/test_dictation.html`
- `templates/test_fill_word.html`
- `templates/test_multiple_choice.html`
- `templates/test_multiple_choice_multiple.html`
- `templates/test_true_false.html`
- `templates/take_test.html`
- `templates/test_start.html`